### PR TITLE
Remove unused 'images' attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To use `v-viewer`, simply import it and the `css` file, and call `Vue.use()` to 
       ...
     </div>
     <!-- component -->
-    <viewer :images="images">
+    <viewer>
       <img v-for="src in images" :src="src" :key="src">
     </viewer>
   </div>
@@ -117,13 +117,13 @@ Listen for the `inited` event to get the `viewer` instance, or use `this.refs.xx
 ```html
 <template>
   <div id="app">
-    <viewer :options="options" :images="images"
+    <viewer :options="options"
             @inited="inited"
             class="viewer" ref="viewer"
     >
-      <template scope="scope">
-        <img v-for="src in scope.images" :src="src" :key="src">
-        {{scope.options}}
+      <template slot-scope="{ options }">
+        <img v-for="src in images" :src="src" :key="src">
+        {{ options }}
       </template>
     </viewer>
     <button type="button" @click="show">Show</button>

--- a/src/component.vue
+++ b/src/component.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <slot :images="images" :options="options">
+    <slot :options="options">
     </slot>
   </div>
 </template>
@@ -9,10 +9,6 @@ import Viewer from 'viewerjs'
 
 export default {
   props: {
-    images: {
-      type: Array,
-      required: true
-    },
     options: {
       type: Object
     }
@@ -35,11 +31,6 @@ export default {
   },
 
   watch: {
-    images () {
-      this.$nextTick(() => {
-        this.createViewer()
-      })
-    },
     options: {
       handler: function () {
         this.$nextTick(() => {


### PR DESCRIPTION
Currently, `<viewer>` component takes the non-optional `images` attribute but then does nothing good with it (in particular, it does *not* render images from it). This is not only useless but deceitful.

For example:

```vue
  <viewer :images="images">
    <!-- images is ignored! -->
    <img src="https://picsum.photos/200/200">
    <img src="https://picsum.photos/300/200">
    <img src="https://picsum.photos/250/200">
  </viewer>
```

Whatever is passed to `images` is not used, although it is required to pass an Array value there.

`images` will be passed as a slot scope argument however this serves no purpose either, because the slot code has direct access to containing component data, for example:

```vue
<template>
  <viewer>
    <slot>
      <!-- no need to pull images from slot scope, it is already available: -->
      <img v-for="image in images" :src="image">
    </slot>
  </viewer>
</template>

<script>
export default {
  data () {
    return {
      images: [ ... ]
    }
  }
}
</script>
```

Codepen demonstrating both problems: https://codepen.io/ilya-semenov/pen/KRKXLv

This PR removes image attribute. It also replaces `scope` with `slot-scope` in the example, as the former is deprecated in Vue 2.5.