### PR TITLE
Add types declaration to add support for typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,16 @@
+import Vue from "vue";
+import ViewerJS from "viewerjs";
+
+declare namespace Viewer {
+  export interface InstallationOptions {
+    name: string;
+    debug: boolean;
+    defaultOptions: ViewerJS.Options;
+  }
+
+  export function install(vue: typeof Vue, options?: InstallationOptions): void;
+
+  export function setDefaults(defaultOptions: ViewerJS.Options): void;
+}
+
+export default Viewer;


### PR DESCRIPTION
This PR contain the type declaration file in order to add support for typescript. ViewerJS already support typescript so we are using their type declaration for the option object.