### PR TITLE
fix: Fix typings (extend vue instead of @vue/runtime-core)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,7 +29,7 @@ export declare const component: DefineComponent<{}, {}, any>
 
 export default VueViewer
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $viewerApi: typeof api
   }


### PR DESCRIPTION
# Changes in PR:
Switched to extending vue instead of @vue/runtime-core as recommended in the official docs. #351 